### PR TITLE
ESU-939: Create QA specs for current state of the project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,10 @@ gem 'rails', '~> 3.2.13'
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
 gem 'blacklight'
-gem 'hesburgh_assets', :git => 'git@git.library.nd.edu:assets'
-gem 'hesburgh_infrastructure', :git => 'git@git.library.nd.edu:hesburgh_infrastructure'
+gem 'hesburgh_assets', :path => 'vendor/bundle/assets'
+gem 'hesburgh_infrastructure', :git => 'https://github.com/ndlib/hesburgh_infrastructure'
 gem 'jquery-rails', '~> 2.1.4'
+gem 'logger', '~> 1.2.8'
 gem 'mysql2', '~> 0.3.11'
 gem 'nokogiri', '~> 1.5.0'
 gem 'paperclip', "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
-    logger (1.2.8)
+    logger (1.2.8.1)
     lumberjack (1.0.4)
     mail (2.5.4)
       mime-types (~> 1.16)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ bundle exec guard
 1. Open http://localhost:3010/import
 2. Import the file from spec/fixtures/test-export.xlsx
 
+Alternatively, run a rake task to do this for you:
+`bundle exec rake import:test`
+
 ## Searching
 
 Searching can be done from http://localhost:3010/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3'
+services:
+  mysql:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile.mysql
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: architecture_drawings_development
+    volumes:
+      - ./docker/mysql-utf8.cnf:/etc/mysql/conf.d/mysql-utf8.cnf
+    healthcheck:
+        interval: 30s
+        timeout: 10s
+        retries: 5
+  rails:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.rails
+    command: bash docker/rails_entry.sh
+    environment:
+      BUNDLE_PATH: "/bundle"
+      MYSQL_HOST: mysql
+      SOLR_HOST: jetty
+      SOLR_PORT: 8983
+      # Need to pass the user running docker into the container so that
+      # config/admin_usernames.yml pulls in the user as an admin. This is
+      # to replicate existing behavior on OSX and may not work correctly on
+      # another OS
+      USER: #{USER}
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mysql
+      - solr
+  solr:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.solr
+    command: bash /solr/jetty.sh start
+    environment:
+      JETTY_HOME: "/jetty"
+    ports:
+      - "8983:8983"

--- a/docker/Dockerfile.chrome.tests
+++ b/docker/Dockerfile.chrome.tests
@@ -1,0 +1,15 @@
+FROM selenium/standalone-chrome:3.141.59
+USER root
+RUN apt-get update && apt-get -y install python-pip && pip install selenium
+
+RUN wget https://chromedriver.storage.googleapis.com/75.0.3770.90/chromedriver_linux64.zip
+RUN unzip chromedriver_linux64.zip -d /usr/local/bin/
+RUN chmod a+x /usr/local/bin/chromedriver
+
+COPY spec spec
+
+RUN useradd -r selenium
+USER selenium
+
+ENV BaseURL 'http://rails:3000'
+CMD exec python spec/feature/chrome_spec.py

--- a/docker/Dockerfile.mysql
+++ b/docker/Dockerfile.mysql
@@ -1,0 +1,5 @@
+FROM mariadb
+
+COPY ./docker/mysql-healthcheck /usr/local/bin/
+
+HEALTHCHECK CMD ["mysql-healthcheck"]

--- a/docker/Dockerfile.rails
+++ b/docker/Dockerfile.rails
@@ -1,0 +1,17 @@
+FROM ruby:2.0.0
+
+
+# Put the installed gems outside of project_root so that the sync volume won't interfere
+RUN mkdir /bundle
+WORKDIR /bundle
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
+COPY vendor/bundle vendor/bundle
+RUN bundle install --path /bundle
+
+RUN mkdir /project_root
+WORKDIR /project_root
+COPY . /project_root
+COPY docker/database.yml /project_root/config/database.yml
+COPY docker/solr.yml /project_root/config/solr.yml
+COPY docker/jetty.yml /project_root/config/jetty.yml

--- a/docker/Dockerfile.solr
+++ b/docker/Dockerfile.solr
@@ -1,0 +1,8 @@
+FROM java:8-jre
+
+RUN mkdir /jetty
+WORKDIR /jetty
+COPY jetty /jetty
+
+ENV JETTY_HOME /jetty
+ENTRYPOINT java -Djetty.port=8983 -Dsolr.solr.home=/jetty/solr -XX:+CMSPermGenSweepingEnabled -XX:+CMSClassUnloadingEnabled -XX:PermSize=64M -XX:MaxPermSize=128M -jar /jetty/start.jar

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+# Docker Instructions
+
+## Running
+To run the full stack of services, including mysql, solr, and rails, using docker-compose:
+```sh
+docker-compose build
+docker-compose up
+```
+
+## Chrome Testing
+Run the following to build and run the Chrome tests against the locally running services using Docker:
+```sh
+docker build -f docker/Dockerfile.chrome.tests -t architecture/tests/chrome .
+docker run \
+  --network="architecture_drawings_default" \
+  --label architecture-tests-chrome architecture/tests/chrome
+```
+
+To test another host, use the default network and override the BaseURL, ex:
+```sh
+docker run \
+  -e BaseURL='https://drawings.library.nd.edu' \
+  --label architecture-tests-chrome architecture/tests/chrome
+```

--- a/docker/database.yml
+++ b/docker/database.yml
@@ -1,0 +1,29 @@
+##########################################
+# Shared settings
+##########################################
+
+mysql_settings: &mysql_settings
+  adapter: mysql2
+  pool:    5
+  timeout: 5000
+  encoding: utf8
+  username: root
+  password: password
+  database: architecture_drawings_development
+  host: mysql
+  port: 3306
+
+development:
+  <<: *mysql_settings
+
+test:
+  <<: *mysql_settings
+
+pre_production:
+  <<: *mysql_settings
+
+production:
+  <<: *mysql_settings
+
+cucumber:
+  <<: *mysql_settings

--- a/docker/jetty.yml
+++ b/docker/jetty.yml
@@ -1,0 +1,2 @@
+default:
+  jetty_port: 8983

--- a/docker/mysql-healthcheck
+++ b/docker/mysql-healthcheck
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eo pipefail
+
+if [ "$MYSQL_RANDOM_ROOT_PASSWORD" ] && [ -z "$MYSQL_USER" ] && [ -z "$MYSQL_PASSWORD" ]; then
+	# there's no way we can guess what the random MySQL password was
+	echo >&2 'healthcheck error: cannot determine random root password (and MYSQL_USER and MYSQL_PASSWORD were not set)'
+	exit 0
+fi
+
+host="$(hostname --ip-address || echo '127.0.0.1')"
+user="${MYSQL_USER:-root}"
+export MYSQL_PWD="${MYSQL_PASSWORD:-$MYSQL_ROOT_PASSWORD}"
+
+args=(
+	# force mysql to not use the local "mysqld.sock" (test "external" connectibility)
+	-h"$host"
+	-u"$user"
+	--silent
+)
+
+if select="$(echo 'SELECT 1' | mysql "${args[@]}")" && [ "$select" = '1' ]; then
+	exit 0
+fi
+
+exit 1

--- a/docker/mysql-utf8.cnf
+++ b/docker/mysql-utf8.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+character-set-server = utf8
+collation-server = utf8_unicode_ci
+skip-character-set-client-handshake

--- a/docker/rails_entry.sh
+++ b/docker/rails_entry.sh
@@ -1,0 +1,13 @@
+# All the things that will execute when starting the rails service
+# Copy the generated lock file back into the project root. This is to sync this change back to the
+# application after the container has mounted the sync volume
+cp /bundle/Gemfile.lock ./
+bash docker/wait-for-it.sh mysql:3306
+bash docker/wait-for-it.sh solr:8983
+bundle exec rake db:schema:load
+# If we find people are ok with just starting a shell in the container and running the db create/load before running specs, then we can remove this
+RAILS_ENV=test bundle exec rake db:create db:schema:load
+
+export RAILS_ENV=development
+bundle exec rake import:test
+exec bundle exec rails s

--- a/docker/solr.yml
+++ b/docker/solr.yml
@@ -1,0 +1,22 @@
+# = jetty_path key
+# each environment can have a jetty_path with absolute or relative
+# (to app root) path to a jetty/solr install. This is used
+# by the rake tasks that start up solr automatically for testing
+# and by rake solr:marc:index.
+#
+# jetty_path is not used by a running Blacklight application
+# at all. In general you do NOT need to deploy solr in Jetty, you can deploy it
+# however you want.
+# jetty_path is only required for rake tasks that need to know
+# how to start up solr, generally for automated testing.
+
+development:
+  url: http://solr:8983/solr
+test: &test
+  url: http://solr:8983/solr
+cucumber:
+  <<: *test
+pre_production:
+  url: http://solr:8983/solr/architecture_drawings
+production:
+  url: http://solr:8983/solr/architecture_drawings

--- a/docker/wait-for-it.sh
+++ b/docker/wait-for-it.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "${CLI[@]}"
+else
+    exit $RESULT
+fi

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,13 @@
+namespace :import do
+  desc "Import test spreadsheet"
+  task :test => :environment do
+    params = Hash[import_file: File.open("spec/fixtures/test-export.xlsx",'r')]
+    @import = FlatFileImport.new(params)
+    if @import.save
+      @import.process_import_file!
+      puts "File 'spec/fixtures/test-export.xlsx' imported successfully."
+    else
+      puts "Failed to import file 'spec/fixtures/test-export.xlsx'."
+    end
+  end
+end

--- a/spec/feature/chrome_spec.py
+++ b/spec/feature/chrome_spec.py
@@ -1,0 +1,65 @@
+
+import unittest
+import os
+import re
+from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver import Chrome
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support import expected_conditions as Expected
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support.ui import WebDriverWait
+
+BaseURL = os.environ.get('BaseURL')
+
+class ChromeSpec(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        options = Options()
+        options.add_argument('-headless')
+        options.add_argument('--disable-dev-shm-usage')
+        options.add_argument('--no-sandbox')
+        cls.driver = Chrome(executable_path='/usr/local/bin/chromedriver', options=options)
+        cls.driver.implicitly_wait(10)
+
+    @classmethod
+    def classTearDown(cls):
+        cls.driver.quit()
+
+    def waitOnHeader(self):
+        # Need to wait for the header to finish loading/wrapping the content. Otherwise a div
+        # will cover links and throw a click exception. Unfortunately, this will
+        # be sensitive to changes in https://github.com/ndlib/drapes
+        try:
+            WebDriverWait(self.driver, 10).until(Expected.presence_of_element_located((By.CLASS_NAME, "hesburgh-wrapped")))
+        except TimeoutException:
+            print "Timed out waiting for header to load"
+
+    def test_home_link(self):
+        driver = self.driver
+        driver.get(BaseURL + '/')
+
+        self.waitOnHeader()
+
+        found_element = driver.find_element_by_link_text('Maps and Plans Collection')
+        found_element.click()
+
+        self.assertEqual(driver.current_url, BaseURL + '/')
+
+
+    def test_search_content(self):
+        driver = self.driver
+        driver.get(BaseURL + '/')
+
+        self.waitOnHeader()
+
+        found_element = driver.find_element_by_id('search')
+        found_element.click()
+
+        found_content = driver.find_element_by_id('content')
+        self.assertEqual(driver.current_url, BaseURL + '/?utf8=%E2%9C%93&search_field=all_fields&q=')
+
+
+suite = unittest.TestLoader().loadTestsFromTestCase(ChromeSpec)
+unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Fixed the current state of the application:
- Fixed a dependency on the logger gem to pull '1.2.8.1' following the direction of https://github.com/nahi/logger/issues/3
- Removed the dependency on our gitolite assets repo by pulling the gem into this repository. The gist of what I did to pull this in:
```sh
git clone git clone git@git.library.nd.edu:assets ~/repos/assets
mkdir vendor/bundle
cp -r ~/repos/assets vendor/bundle/assets
rm -rf vendor/bundle/assets/.git
```

Added Tests:
- Added a set of feature tests to run with Selenium/Chrome that can be pointed to a target host with BaseURL env
- Added two basic tests for now to hit the home page and the search page

Dockerized the application:
- Added a compose and dockerfiles for all services needed to run the application (mysql, solr, rails)
- Added a rake task in order to automate adding the test data and included this when starting the rails container
- Added a separate dockerfile for more easily running tests without installing the selenium stuff. Not sure if I want this to run within the compose, and doing the multiple compose thing just for this seems overkill.
- Added a README for all of the docker stuff, including how to run the Chrome tests in a container