### PR TITLE
Fix tests

### DIFF
--- a/docker/Dockerfile.chrome.tests
+++ b/docker/Dockerfile.chrome.tests
@@ -2,10 +2,6 @@ FROM selenium/standalone-chrome:3.141.59
 USER root
 RUN apt-get update && apt-get -y install python-pip && pip install selenium
 
-RUN wget https://chromedriver.storage.googleapis.com/75.0.3770.90/chromedriver_linux64.zip
-RUN unzip chromedriver_linux64.zip -d /usr/local/bin/
-RUN chmod a+x /usr/local/bin/chromedriver
-
 COPY spec spec
 
 RUN useradd -r selenium

--- a/spec/feature/chrome_spec.py
+++ b/spec/feature/chrome_spec.py
@@ -21,7 +21,7 @@ class ChromeSpec(unittest.TestCase):
         options.add_argument('-headless')
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--no-sandbox')
-        cls.driver = Chrome(executable_path='/usr/local/bin/chromedriver', options=options)
+        cls.driver = Chrome(options=options)
         cls.driver.implicitly_wait(10)
 
     @classmethod
@@ -34,6 +34,7 @@ class ChromeSpec(unittest.TestCase):
         # be sensitive to changes in https://github.com/ndlib/drapes
         try:
             WebDriverWait(self.driver, 10).until(Expected.presence_of_element_located((By.CLASS_NAME, "hesburgh-wrapped")))
+            WebDriverWait(self.driver, 10).until(Expected.presence_of_element_located((By.XPATH, "//nav[@aria-label='Main Navigation']")))
         except TimeoutException:
             self.fail("Timed out waiting for header to load")
 


### PR DESCRIPTION
A new version of chrome made it's way into the selenium docker image in github and broke the tests. Tests here broke because of the explicit download of a chromedriver, even though it's already in the base image. Removed this download and changed the tests to load the chromedriver from the normal PATH.

Additionally still having intermittent issues with the browser being unable to click on things because of the async nature of how the header gets loaded in. Added an additional check to wait for one of the elements that are added by the header's js. Probably don't need to wait for hesburgh-wrapped any longer, but figured it couldn't hurt.